### PR TITLE
API naming changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.salesforce.functions</groupId>
     <artifactId>sf-fx-sdk-java</artifactId>
-    <version>0.1.0-ea</version>
+    <version>0.2.0-ea-SNAPSHOT</version>
 
     <name>sf-fx-sdk-java</name>
     <description>Salesforce Function SDK for Java</description>

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApi.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApi.java
@@ -24,13 +24,13 @@ public interface DataApi {
     UnitOfWork newUnitOfWork();
 
     /**
-     * Creates a new {@link RecordInsert} for the given object type.
+     * Creates a new {@link RecordCreate} for the given object type.
      *
-     * @param type The type of record to insert.
-     * @return a new {@link RecordInsert}
+     * @param type The type of record to create.
+     * @return a new {@link RecordCreate}
      */
     @Nonnull
-    RecordInsert newRecordInsert(String type);
+    RecordCreate newRecordCreate(String type);
 
     /**
      * Creates a new {@link RecordUpdate} for the given object type and record id.
@@ -45,8 +45,8 @@ public interface DataApi {
     /**
      * Commits a {@link UnitOfWork}, executing all operations registered with it. If any of these operations fail, the
      * whole unit is rolled back. To examine results for a single operation, inspect the returned map (which is keyed
-     * with {@link ReferenceId} returned from {@link UnitOfWork#insert(RecordInsert)} and
-     * {@link UnitOfWork#update(RecordUpdate)}.
+     * with {@link ReferenceId} returned from {@link UnitOfWork#registerCreate(RecordCreate)} and
+     * {@link UnitOfWork#registerUpdate(RecordUpdate)}.
      *
      * @param unitOfWork The {@link UnitOfWork} to commit.
      * @return A map of {@link RecordModificationResult}s.
@@ -56,14 +56,14 @@ public interface DataApi {
     Map<ReferenceId, RecordModificationResult> commitUnitOfWork(UnitOfWork unitOfWork) throws IOException;
 
     /**
-     * Inserts a new record described by the given {@link RecordInsert}.
+     * Creates a new record described by the given {@link RecordCreate}.
      *
-     * @param insert The record insert description. Must be obtained via {@link #newRecordInsert(String)}.
+     * @param create The record creation description. Must be obtained via {@link #newRecordCreate(String)}.
      * @return
      * @throws IOException If an IO related error occurred.
      */
     @Nonnull
-    RecordModificationResult insert(RecordInsert insert) throws IOException;
+    RecordModificationResult create(RecordCreate create) throws IOException;
 
     /**
      * Updates an existing record described by the given {@link RecordUpdate}.

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordCreate.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordCreate.java
@@ -9,7 +9,7 @@ package com.salesforce.functions.jvm.sdk.data;
 
 import javax.annotation.Nonnull;
 
-public interface RecordInsert extends RecordModification<RecordInsert> {
+public interface RecordCreate extends RecordModification<RecordCreate> {
     @Nonnull
     String getType();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordModification.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordModification.java
@@ -13,41 +13,41 @@ import java.math.BigInteger;
 
 public interface RecordModification<T extends RecordModification<T>> {
     @Nonnull
-    T setStringValue(String key, String value);
+    T setValue(String key, String value);
 
     @Nonnull
-    T setShortValue(String key, short value);
+    T setValue(String key, short value);
 
     @Nonnull
-    T setNumberValue(String key, Number value);
+    T setValue(String key, Number value);
 
     @Nonnull
-    T setLongValue(String key, long value);
+    T setValue(String key, long value);
 
     @Nonnull
-    T setIntValue(String key, int value);
+    T setValue(String key, int value);
 
     @Nonnull
-    T setFloatValue(String key, float value);
+    T setValue(String key, float value);
 
     @Nonnull
-    T setDoubleValue(String key, double value);
+    T setValue(String key, double value);
 
     @Nonnull
-    T setCharacterValue(String key, char value);
+    T setValue(String key, char value);
 
     @Nonnull
-    T setByteValue(String key, byte value);
+    T setValue(String key, byte value);
 
     @Nonnull
-    T setBooleanValue(String key, boolean value);
+    T setValue(String key, boolean value);
 
     @Nonnull
-    T setBigIntegerValue(String key, BigInteger value);
+    T setValue(String key, BigInteger value);
 
     @Nonnull
-    T setBigDecimalValue(String key, BigDecimal value);
+    T setValue(String key, BigDecimal value);
 
     @Nonnull
-    T setReferenceIdValue(String key, ReferenceId fkId);
+    T setValue(String key, ReferenceId fkId);
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/UnitOfWork.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/UnitOfWork.java
@@ -4,15 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
 import javax.annotation.Nonnull;
 
 public interface UnitOfWork {
     @Nonnull
-    ReferenceId insert(RecordInsert insert);
+    ReferenceId registerCreate(RecordCreate create);
 
     @Nonnull
-    ReferenceId update(RecordUpdate update);
+    ReferenceId registerUpdate(RecordUpdate update);
 }


### PR DESCRIPTION
- Record `insert`s have been renamed to `create` for consistency with the Salesforce REST API.
- `setXValue` methods on `RecordModification` have been consolidated into overloaded `setValue` methods.

Closes [W-9117233](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000AU0EYAW/view)