### PR TITLE
Add spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,53 @@
 
         <plugins>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.9.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <formats>
+                        <format>
+                            <includes>
+                                <include>**/src/main/*.java</include>
+                                <include>**/src/test/*.java</include>
+                                <include>**/pom.xml</include>
+                            </includes>
+
+                            <trimTrailingWhitespace/>
+                            <endWithNewline/>
+                        </format>
+                    </formats>
+
+                    <java>
+                        <googleJavaFormat>
+                            <version>1.7</version>
+                            <style>GOOGLE</style>
+                        </googleJavaFormat>
+
+                        <licenseHeader>
+                            <content>
+                                <![CDATA[
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+]]>
+                            </content>
+                        </licenseHeader>
+                    </java>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>

--- a/src/main/java/com/salesforce/functions/jvm/sdk/Context.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/Context.java
@@ -4,30 +4,31 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk;
 
-import javax.annotation.Nonnull;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 /**
- * Represents the connection to the the execution environment and the Customer 360 instance that the function is
- * associated with.
+ * Represents the connection to the the execution environment and the Customer 360 instance that the
+ * function is associated with.
  */
 public interface Context {
-    /**
-     * Returns the unique identifier for a given execution of a function.
-     *
-     * @return The unique identifier for a given execution of a function.
-     */
-    @Nonnull
-    String getId();
+  /**
+   * Returns the unique identifier for a given execution of a function.
+   *
+   * @return The unique identifier for a given execution of a function.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getId();
 
-    /**
-     * Returns information about the invoking Salesforce organization and user in Customer 360.
-     *
-     * @return Information about the invoking Salesforce organization and user in Customer 360.
-     */
-    @Nonnull
-    Optional<Org> getOrg();
+  /**
+   * Returns information about the invoking Salesforce organization and user in Customer 360.
+   *
+   * @return Information about the invoking Salesforce organization and user in Customer 360.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Org> getOrg();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/InvocationEvent.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/InvocationEvent.java
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 /**
  * An Event is representative of the data associated with the occurrence of an event, and supporting
@@ -19,77 +18,93 @@ import java.util.Optional;
  * @param <T> The type of the payload of this event.
  */
 public interface InvocationEvent<T> {
-    /**
-     * Returns the platform event occurrence id for event invocation.
-     *
-     * @return The platform event occurrence id for event invocation.
-     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#id">CloudEvent Specification</a>
-     */
-    @Nonnull
-    String getId();
+  /**
+   * Returns the platform event occurrence id for event invocation.
+   *
+   * @return The platform event occurrence id for event invocation.
+   * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#id">CloudEvent
+   *     Specification</a>
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getId();
 
-    /**
-     * Returns a value describing the type of invocation. The format of this is producer defined and might include
-     * information such as the version of the type.
-     *
-     * @return A string describing the type of invocation.
-     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#type">CloudEvent Specification</a>
-     */
-    @Nonnull
-    String getType();
+  /**
+   * Returns a value describing the type of invocation. The format of this is producer defined and
+   * might include information such as the version of the type.
+   *
+   * @return A string describing the type of invocation.
+   * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#type">CloudEvent
+   *     Specification</a>
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getType();
 
-    /**
-     * Returns an URI which Identifies the context in which an event happened. Often this will include information such
-     * as the type of the event source, the organization publishing the event or the process that produced the event.
-     *
-     * @return An URI  which Identifies the context in which an event happened.
-     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#source-1">CloudEvent Specification</a>
-     */
-    @Nonnull
-    URI getSource();
+  /**
+   * Returns an URI which Identifies the context in which an event happened. Often this will include
+   * information such as the type of the event source, the organization publishing the event or the
+   * process that produced the event.
+   *
+   * @return An URI which Identifies the context in which an event happened.
+   * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#source-1">CloudEvent
+   *     Specification</a>
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  URI getSource();
 
-    /**
-     * Returns the unmarshalled payload of the event.
-     *
-     * @return The payload of the event.
-     */
-    @Nonnull
-    T getData();
+  /**
+   * Returns the unmarshalled payload of the event.
+   *
+   * @return The payload of the event.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  T getData();
 
-    /**
-     * Returns the media type of the event payload that is accessible via {@link InvocationEvent#getData()}. This is
-     * valid for the original data that was posted to the function before it was automatically unmarshalled into
-     * {@link T}.
-     * <p>
-     * When using POJOs and other higher level types for {@link T}, this value is most likely not very useful.
-     * When using raw bytes (by using byte[] for T), this value can be used to drive your custom unmarshalling process.
-     *
-     * @return The media type of the event payload.
-     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#datacontenttype">CloudEvent Specification</a>
-     */
-    @Nonnull
-    Optional<String> getDataContentType();
+  /**
+   * Returns the media type of the event payload that is accessible via {@link
+   * InvocationEvent#getData()}. This is valid for the original data that was posted to the function
+   * before it was automatically unmarshalled into {@link T}.
+   *
+   * <p>When using POJOs and other higher level types for {@link T}, this value is most likely not
+   * very useful. When using raw bytes (by using byte[] for T), this value can be used to drive your
+   * custom unmarshalling process.
+   *
+   * @return The media type of the event payload.
+   * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#datacontenttype">CloudEvent
+   *     Specification</a>
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<String> getDataContentType();
 
-    /**
-     * Returns the schema that the event payload adheres to.
-     *
-     * @return The schema that the event payload adheres to.
-     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#dataschema">CloudEvent Specification</a>
-     */
-    @Nonnull
-    Optional<URI> getDataSchema();
+  /**
+   * Returns the schema that the event payload adheres to.
+   *
+   * @return The schema that the event payload adheres to.
+   * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#dataschema">CloudEvent
+   *     Specification</a>
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<URI> getDataSchema();
 
-    /**
-     * Returns the timestamp of when the occurrence happened. If the time of the occurrence cannot be determined then
-     * this attribute may be set to some other time (such as the current time), however all producers for the same
-     * source must be consistent in this respect. In other words, either they all use the actual time of the occurrence
-     * or they all use the same algorithm to determine the value used.
-     * <p>
-     * {@link InvocationEvent#getSource}
-     *
-     * @return The timestamp of when the occurrence happened
-     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#time">CloudEvent Specification</a>
-     */
-    @Nonnull
-    Optional<OffsetDateTime> getTime();
+  /**
+   * Returns the timestamp of when the occurrence happened. If the time of the occurrence cannot be
+   * determined then this attribute may be set to some other time (such as the current time),
+   * however all producers for the same source must be consistent in this respect. In other words,
+   * either they all use the actual time of the occurrence or they all use the same algorithm to
+   * determine the value used.
+   *
+   * <p>{@link InvocationEvent#getSource}
+   *
+   * @return The timestamp of when the occurrence happened
+   * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#time">CloudEvent
+   *     Specification</a>
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<OffsetDateTime> getTime();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/Org.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/Org.java
@@ -4,52 +4,55 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk;
 
 import com.salesforce.functions.jvm.sdk.data.DataApi;
-
-import javax.annotation.Nonnull;
 import java.net.URI;
+import javax.annotation.Nonnull;
 
-/**
- * Holds information about the invoking Salesforce organization and user in Customer 360.
- */
+/** Holds information about the invoking Salesforce organization and user in Customer 360. */
 public interface Org {
-    /**
-     * Returns the Salesforce organization ID.
-     *
-     * @return The Salesforce organization ID.
-     */
-    @Nonnull
-    String getId();
+  /**
+   * Returns the Salesforce organization ID.
+   *
+   * @return The Salesforce organization ID.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getId();
 
-    /**
-     * Returns the base URL of the Salesforce organization.
-     *
-     * @return The base URL of the Salesforce organization.
-     */
-    @Nonnull
-    URI getBaseUrl();
+  /**
+   * Returns the base URL of the Salesforce organization.
+   *
+   * @return The base URL of the Salesforce organization.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  URI getBaseUrl();
 
-    /**
-     * Returns the domain URL of the Salesforce organization.
-     *
-     * @return The domain URL of the Salesforce organization.
-     */
-    @Nonnull
-    URI getDomainUrl();
+  /**
+   * Returns the domain URL of the Salesforce organization.
+   *
+   * @return The domain URL of the Salesforce organization.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  URI getDomainUrl();
 
-    /**
-     * Returns the API version the Salesforce organization is currently using.
-     *
-     * @return The API version the Salesforce organization is currently using.
-     */
-    String getApiVersion();
+  /**
+   * Returns the API version the Salesforce organization is currently using.
+   *
+   * @return The API version the Salesforce organization is currently using.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getApiVersion();
 
-    @Nonnull
-    DataApi getDataApi();
+  @Nonnull
+  @SuppressWarnings("unused")
+  DataApi getDataApi();
 
-    @Nonnull
-    User getUser();
+  @Nonnull
+  @SuppressWarnings("unused")
+  User getUser();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/SalesforceFunction.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/SalesforceFunction.java
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk;
 
 import java.util.function.BiFunction;
@@ -15,7 +14,8 @@ import java.util.function.BiFunction;
  * @param <T> The type of the {@link InvocationEvent} payload this function can handle.
  * @param <R> The type of the response of this function.
  */
+@SuppressWarnings("unused")
 public interface SalesforceFunction<T, R> extends BiFunction<InvocationEvent<T>, Context, R> {
-    @Override
-    R apply(InvocationEvent<T> tInvocationEvent, Context context);
+  @Override
+  R apply(InvocationEvent<T> tInvocationEvent, Context context);
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/User.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/User.java
@@ -4,32 +4,32 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk;
 
-import javax.annotation.Nonnull;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
-/**
- * Holds information about the invoking Salesforce user in Customer 360.
- */
+/** Holds information about the invoking Salesforce user in Customer 360. */
 public interface User {
-    /**
-     * Returns the user's ID.
-     *
-     * @return The user's ID.
-     */
-    @Nonnull
-    String getId();
+  /**
+   * Returns the user's ID.
+   *
+   * @return The user's ID.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getId();
 
-    /**
-     * Returns the name of the user.
-     *
-     * @return The name of the user.
-     */
-    @Nonnull
-    String getUsername();
+  /**
+   * Returns the name of the user.
+   *
+   * @return The name of the user.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getUsername();
 
-    @Nonnull
-    Optional<String> getOnBehalfOfUserId();
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<String> getOnBehalfOfUserId();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApi.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApi.java
@@ -4,105 +4,117 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 public interface DataApi {
-    /**
-     * Creates a new and empty {@link UnitOfWork}.
-     * <p>
-     * Use the methods on UnitOfWork to add work to it. UnitOfWork instances can be committed by using the
-     * {@link #commitUnitOfWork(UnitOfWork)} method on {@link DataApi}.
-     *
-     * @return a new and empty {@link UnitOfWork}.
-     */
-    @Nonnull
-    UnitOfWork newUnitOfWork();
+  /**
+   * Creates a new and empty {@link UnitOfWork}.
+   *
+   * <p>Use the methods on UnitOfWork to add work to it. UnitOfWork instances can be committed by
+   * using the {@link #commitUnitOfWork(UnitOfWork)} method on {@link DataApi}.
+   *
+   * @return a new and empty {@link UnitOfWork}.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  UnitOfWork newUnitOfWork();
 
-    /**
-     * Creates a new {@link RecordCreate} for the given object type.
-     *
-     * @param type The type of record to create.
-     * @return a new {@link RecordCreate}
-     */
-    @Nonnull
-    RecordCreate newRecordCreate(String type);
+  /**
+   * Creates a new {@link RecordCreate} for the given object type.
+   *
+   * @param type The type of record to create.
+   * @return a new {@link RecordCreate}
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  RecordCreate newRecordCreate(String type);
 
-    /**
-     * Creates a new {@link RecordUpdate} for the given object type and record id.
-     *
-     * @param type The type of record to update.
-     * @param id   The ID of the record to update.
-     * @return a new {@link RecordUpdate}
-     */
-    @Nonnull
-    RecordUpdate newRecordUpdate(String type, String id);
+  /**
+   * Creates a new {@link RecordUpdate} for the given object type and record id.
+   *
+   * @param type The type of record to update.
+   * @param id The ID of the record to update.
+   * @return a new {@link RecordUpdate}
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  RecordUpdate newRecordUpdate(String type, String id);
 
-    /**
-     * Commits a {@link UnitOfWork}, executing all operations registered with it. If any of these operations fail, the
-     * whole unit is rolled back. To examine results for a single operation, inspect the returned map (which is keyed
-     * with {@link ReferenceId} returned from {@link UnitOfWork#registerCreate(RecordCreate)} and
-     * {@link UnitOfWork#registerUpdate(RecordUpdate)}.
-     *
-     * @param unitOfWork The {@link UnitOfWork} to commit.
-     * @return A map of {@link RecordModificationResult}s.
-     * @throws IOException If an IO related error occurred.
-     */
-    @Nonnull
-    Map<ReferenceId, RecordModificationResult> commitUnitOfWork(UnitOfWork unitOfWork) throws IOException;
+  /**
+   * Commits a {@link UnitOfWork}, executing all operations registered with it. If any of these
+   * operations fail, the whole unit is rolled back. To examine results for a single operation,
+   * inspect the returned map (which is keyed with {@link ReferenceId} returned from {@link
+   * UnitOfWork#registerCreate(RecordCreate)} and {@link UnitOfWork#registerUpdate(RecordUpdate)}.
+   *
+   * @param unitOfWork The {@link UnitOfWork} to commit.
+   * @return A map of {@link RecordModificationResult}s.
+   * @throws IOException If an IO related error occurred.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Map<ReferenceId, RecordModificationResult> commitUnitOfWork(UnitOfWork unitOfWork)
+      throws IOException;
 
-    /**
-     * Creates a new record described by the given {@link RecordCreate}.
-     *
-     * @param create The record creation description. Must be obtained via {@link #newRecordCreate(String)}.
-     * @return
-     * @throws IOException If an IO related error occurred.
-     */
-    @Nonnull
-    RecordModificationResult create(RecordCreate create) throws IOException;
+  /**
+   * Creates a new record described by the given {@link RecordCreate}.
+   *
+   * @param create The record creation description. Must be obtained via {@link
+   *     #newRecordCreate(String)}.
+   * @return A RecordModificationResult representing the result for this operation.
+   * @throws IOException If an IO related error occurred.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  RecordModificationResult create(RecordCreate create) throws IOException;
 
-    /**
-     * Updates an existing record described by the given {@link RecordUpdate}.
-     *
-     * @param update The record update description. Must be obtained via {@link #newRecordUpdate(String, String)}.
-     * @return
-     * @throws IOException If an IO related error occurred.
-     */
-    @Nonnull
-    RecordModificationResult update(RecordUpdate update) throws IOException;
+  /**
+   * Updates an existing record described by the given {@link RecordUpdate}.
+   *
+   * @param update The record update description. Must be obtained via {@link
+   *     #newRecordUpdate(String, String)}.
+   * @return A RecordModificationResult representing the result for this operation.
+   * @throws IOException If an IO related error occurred.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  RecordModificationResult update(RecordUpdate update) throws IOException;
 
-    /**
-     * Queries for records with a given SOQL string.
-     *
-     * @param soql The SOQL string.
-     * @return a {@link RecordQueryResult} that contains the queried data.
-     * @throws IOException If an IO related error occurred.
-     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm">Salesforce Object Query Language (SOQL)</a>
-     */
-    @Nonnull
-    RecordQueryResult query(String soql) throws IOException;
+  /**
+   * Queries for records with a given SOQL string.
+   *
+   * @param soql The SOQL string.
+   * @return a {@link RecordQueryResult} that contains the queried data.
+   * @throws IOException If an IO related error occurred.
+   * @see <a
+   *     href="https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm">Salesforce
+   *     Object Query Language (SOQL)</a>
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  RecordQueryResult query(String soql) throws IOException;
 
-    /**
-     * Queries for more records, based on the given {@link RecordQueryResult}.
-     *
-     * @param queryResult The query result to query more data for.
-     * @return A new {@link RecordQueryResult} with additional data.
-     * @throws IOException If an IO related error occurred.
-     */
-    @Nonnull
-    RecordQueryResult queryMore(RecordQueryResult queryResult) throws IOException;
+  /**
+   * Queries for more records, based on the given {@link RecordQueryResult}.
+   *
+   * @param queryResult The query result to query more data for.
+   * @return A new {@link RecordQueryResult} with additional data.
+   * @throws IOException If an IO related error occurred.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  RecordQueryResult queryMore(RecordQueryResult queryResult) throws IOException;
 
-    /**
-     * Returns the access token used by this API client. Can be used to initialize a third-party API client
-     * or to perform custom API calls with a HTTP library.
-     *
-     * @return the access token used by this API client.
-     */
-    @Nonnull
-    String getAccessToken();
+  /**
+   * Returns the access token used by this API client. Can be used to initialize a third-party API
+   * client or to perform custom API calls with a HTTP library.
+   *
+   * @return the access token used by this API client.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getAccessToken();
 }
-

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/Record.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/Record.java
@@ -4,129 +4,152 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
-
-import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 public interface Record {
-    /**
-     * Returns the type of the record.
-     *
-     * @return The type of the record.
-     */
-    @Nonnull
-    String getType();
+  /**
+   * Returns the type of the record.
+   *
+   * @return The type of the record.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getType();
 
-    /**
-     * Returns the value of key as a {@link String}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as a {@link String} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<String> getStringValue(String key);
+  /**
+   * Returns the value of key as a {@link String}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as a {@link String} or empty {@link Optional} if the value is not
+   *     present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<String> getStringValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Short}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as a {@link Short} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Short> getShortValue(String key);
+  /**
+   * Returns the value of key as a {@link Short}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as a {@link Short} or empty {@link Optional} if the value is not
+   *     present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Short> getShortValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Number}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as a {@link Number} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Number> getNumberValue(String key);
+  /**
+   * Returns the value of key as a {@link Number}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as a {@link Number} or empty {@link Optional} if the value is not
+   *     present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Number> getNumberValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Long}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as a {@link Long} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Long> getLongValue(String key);
+  /**
+   * Returns the value of key as a {@link Long}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as a {@link Long} or empty {@link Optional} if the value is not
+   *     present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Long> getLongValue(String key);
 
-    /**
-     * Returns the value of key as an {@link Integer}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link Integer} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Integer> getIntValue(String key);
+  /**
+   * Returns the value of key as an {@link Integer}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link Integer} or empty {@link Optional} if the value is
+   *     not present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Integer> getIntValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Float}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link Float} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Float> getFloatValue(String key);
+  /**
+   * Returns the value of key as a {@link Float}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link Float} or empty {@link Optional} if the value is not
+   *     present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Float> getFloatValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Double}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link Double} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Double> getDoubleValue(String key);
+  /**
+   * Returns the value of key as a {@link Double}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link Double} or empty {@link Optional} if the value is not
+   *     present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Double> getDoubleValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Character}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link Character} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Character> getCharacterValue(String key);
+  /**
+   * Returns the value of key as a {@link Character}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link Character} or empty {@link Optional} if the value is
+   *     not present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Character> getCharacterValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Byte}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link Byte} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Byte> getByteValue(String key);
+  /**
+   * Returns the value of key as a {@link Byte}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link Byte} or empty {@link Optional} if the value is not
+   *     present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Byte> getByteValue(String key);
 
-    /**
-     * Returns the value of key as a {@link Boolean}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link Boolean} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<Boolean> getBooleanValue(String key);
+  /**
+   * Returns the value of key as a {@link Boolean}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link Boolean} or empty {@link Optional} if the value is
+   *     not present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Boolean> getBooleanValue(String key);
 
-    /**
-     * Returns the value of key as an {@link BigInteger}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link BigInteger} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<BigInteger> getBigIntegerValue(String key);
+  /**
+   * Returns the value of key as an {@link BigInteger}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link BigInteger} or empty {@link Optional} if the value is
+   *     not present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<BigInteger> getBigIntegerValue(String key);
 
-    /**
-     * Returns the value of key as an {@link BigDecimal}.
-     *
-     * @param key The key to obtain the value from.
-     * @return The value of the key as an {@link BigInteger} or empty {@link Optional} if the value is not present or null.
-     */
-    @Nonnull
-    Optional<BigDecimal> getBigDecimalValue(String key);
+  /**
+   * Returns the value of key as an {@link BigDecimal}.
+   *
+   * @param key The key to obtain the value from.
+   * @return The value of the key as an {@link BigInteger} or empty {@link Optional} if the value is
+   *     not present or null.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<BigDecimal> getBigDecimalValue(String key);
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordCreate.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordCreate.java
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
 import javax.annotation.Nonnull;
 
 public interface RecordCreate extends RecordModification<RecordCreate> {
-    @Nonnull
-    String getType();
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getType();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordModification.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordModification.java
@@ -4,50 +4,62 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
-import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import javax.annotation.Nonnull;
 
 public interface RecordModification<T extends RecordModification<T>> {
-    @Nonnull
-    T setValue(String key, String value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, String value);
 
-    @Nonnull
-    T setValue(String key, short value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, short value);
 
-    @Nonnull
-    T setValue(String key, Number value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, Number value);
 
-    @Nonnull
-    T setValue(String key, long value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, long value);
 
-    @Nonnull
-    T setValue(String key, int value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, int value);
 
-    @Nonnull
-    T setValue(String key, float value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, float value);
 
-    @Nonnull
-    T setValue(String key, double value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, double value);
 
-    @Nonnull
-    T setValue(String key, char value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, char value);
 
-    @Nonnull
-    T setValue(String key, byte value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, byte value);
 
-    @Nonnull
-    T setValue(String key, boolean value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, boolean value);
 
-    @Nonnull
-    T setValue(String key, BigInteger value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, BigInteger value);
 
-    @Nonnull
-    T setValue(String key, BigDecimal value);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, BigDecimal value);
 
-    @Nonnull
-    T setValue(String key, ReferenceId fkId);
+  @Nonnull
+  @SuppressWarnings("unused")
+  T setValue(String key, ReferenceId fkId);
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordModificationResult.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordModificationResult.java
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
 import javax.annotation.Nonnull;
 
 public interface RecordModificationResult {
-    @Nonnull
-    String getId();
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getId();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordQueryResult.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordQueryResult.java
@@ -4,17 +4,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
-import javax.annotation.Nonnull;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 public interface RecordQueryResult {
-    boolean isDone();
+  @SuppressWarnings("unused")
+  boolean isDone();
 
-    long getTotalSize();
+  @SuppressWarnings("unused")
+  long getTotalSize();
 
-    @Nonnull
-    List<Record> getRecords();
+  @Nonnull
+  @SuppressWarnings("unused")
+  List<Record> getRecords();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordUpdate.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/RecordUpdate.java
@@ -4,15 +4,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
 import javax.annotation.Nonnull;
 
 public interface RecordUpdate extends RecordModification<RecordUpdate> {
-    @Nonnull
-    String getType();
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getType();
 
-    @Nonnull
-    String getId();
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getId();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/ReferenceId.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/ReferenceId.java
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 package com.salesforce.functions.jvm.sdk.data;
 
 import javax.annotation.Nonnull;
 
 public interface ReferenceId {
-    @Nonnull
-    String toApiString();
+  @Nonnull
+  @SuppressWarnings("unused")
+  String toApiString();
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/UnitOfWork.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/UnitOfWork.java
@@ -9,9 +9,11 @@ package com.salesforce.functions.jvm.sdk.data;
 import javax.annotation.Nonnull;
 
 public interface UnitOfWork {
-    @Nonnull
-    ReferenceId registerCreate(RecordCreate create);
+  @Nonnull
+  @SuppressWarnings("unused")
+  ReferenceId registerCreate(RecordCreate create);
 
-    @Nonnull
-    ReferenceId registerUpdate(RecordUpdate update);
+  @Nonnull
+  @SuppressWarnings("unused")
+  ReferenceId registerUpdate(RecordUpdate update);
 }


### PR DESCRIPTION
Like [sf-fx-runtime-java](https://github.com/forcedotcom/sf-fx-runtime-java), this project now uses [spotless](https://github.com/diffplug/spotless) to enforce code style. This PR also applies all the necessary changes to the source to pass spotless.

In addition, several `@SuppressWarnings("unused")` annotations have been added. Those methods are not used in the SDK itself and are not testable since this repository only contains interfaces.

Closes [W-9117411](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000AUE6YAO/view)