### PR TITLE
Various API changes

### DIFF
--- a/src/main/java/com/salesforce/functions/jvm/sdk/SalesforceFunction.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/SalesforceFunction.java
@@ -6,16 +6,24 @@
  */
 package com.salesforce.functions.jvm.sdk;
 
-import java.util.function.BiFunction;
-
 /**
  * Main interface for Salesforce Functions written in Java.
  *
  * @param <T> The type of the {@link InvocationEvent} payload this function can handle.
  * @param <R> The type of the response of this function.
+ * @see java.util.function.BiFunction
  */
 @SuppressWarnings("unused")
-public interface SalesforceFunction<T, R> extends BiFunction<InvocationEvent<T>, Context, R> {
-  @Override
-  R apply(InvocationEvent<T> tInvocationEvent, Context context);
+@FunctionalInterface
+public interface SalesforceFunction<T, R> {
+
+  /**
+   * Applies the function to the given arguments.
+   *
+   * @param event The invocation event for this function application.
+   * @param context The context for this function application.
+   * @return The result of this function application.
+   * @throws Exception If an unrecoverable exception occurred during function application.
+   */
+  R apply(InvocationEvent<T> event, Context context) throws Exception;
 }

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApi.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApi.java
@@ -6,10 +6,10 @@
  */
 package com.salesforce.functions.jvm.sdk.data;
 
-import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
+/** Data API client to interact with data in a Salesforce org. */
 public interface DataApi {
   /**
    * Creates a new and empty {@link UnitOfWork}.
@@ -17,7 +17,7 @@ public interface DataApi {
    * <p>Use the methods on UnitOfWork to add work to it. UnitOfWork instances can be committed by
    * using the {@link #commitUnitOfWork(UnitOfWork)} method on {@link DataApi}.
    *
-   * @return a new and empty {@link UnitOfWork}.
+   * @return A new and empty {@link UnitOfWork}.
    */
   @Nonnull
   @SuppressWarnings("unused")
@@ -27,7 +27,7 @@ public interface DataApi {
    * Creates a new {@link RecordCreate} for the given object type.
    *
    * @param type The type of record to create.
-   * @return a new {@link RecordCreate}
+   * @return A new {@link RecordCreate}
    */
   @Nonnull
   @SuppressWarnings("unused")
@@ -36,9 +36,9 @@ public interface DataApi {
   /**
    * Creates a new {@link RecordUpdate} for the given object type and record id.
    *
-   * @param type The type of record to update.
+   * @param type The object type of record to update.
    * @param id The ID of the record to update.
-   * @return a new {@link RecordUpdate}
+   * @return A new {@link RecordUpdate}
    */
   @Nonnull
   @SuppressWarnings("unused")
@@ -52,12 +52,12 @@ public interface DataApi {
    *
    * @param unitOfWork The {@link UnitOfWork} to commit.
    * @return A map of {@link RecordModificationResult}s.
-   * @throws IOException If an IO related error occurred.
+   * @throws DataApiException If an error occurred while committing the UnitOfWork.
    */
   @Nonnull
   @SuppressWarnings("unused")
   Map<ReferenceId, RecordModificationResult> commitUnitOfWork(UnitOfWork unitOfWork)
-      throws IOException;
+      throws DataApiException;
 
   /**
    * Creates a new record described by the given {@link RecordCreate}.
@@ -65,11 +65,11 @@ public interface DataApi {
    * @param create The record creation description. Must be obtained via {@link
    *     #newRecordCreate(String)}.
    * @return A RecordModificationResult representing the result for this operation.
-   * @throws IOException If an IO related error occurred.
+   * @throws DataApiException If an error occurred during the creation.
    */
   @Nonnull
   @SuppressWarnings("unused")
-  RecordModificationResult create(RecordCreate create) throws IOException;
+  RecordModificationResult create(RecordCreate create) throws DataApiException;
 
   /**
    * Updates an existing record described by the given {@link RecordUpdate}.
@@ -77,36 +77,36 @@ public interface DataApi {
    * @param update The record update description. Must be obtained via {@link
    *     #newRecordUpdate(String, String)}.
    * @return A RecordModificationResult representing the result for this operation.
-   * @throws IOException If an IO related error occurred.
+   * @throws DataApiException If an error occurred during the update.
    */
   @Nonnull
   @SuppressWarnings("unused")
-  RecordModificationResult update(RecordUpdate update) throws IOException;
+  RecordModificationResult update(RecordUpdate update) throws DataApiException;
 
   /**
    * Queries for records with a given SOQL string.
    *
    * @param soql The SOQL string.
    * @return a {@link RecordQueryResult} that contains the queried data.
-   * @throws IOException If an IO related error occurred.
+   * @throws DataApiException If error occurred during the query.
    * @see <a
    *     href="https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm">Salesforce
    *     Object Query Language (SOQL)</a>
    */
   @Nonnull
   @SuppressWarnings("unused")
-  RecordQueryResult query(String soql) throws IOException;
+  RecordQueryResult query(String soql) throws DataApiException;
 
   /**
    * Queries for more records, based on the given {@link RecordQueryResult}.
    *
    * @param queryResult The query result to query more data for.
    * @return A new {@link RecordQueryResult} with additional data.
-   * @throws IOException If an IO related error occurred.
+   * @throws DataApiException If error occurred during the query.
    */
   @Nonnull
   @SuppressWarnings("unused")
-  RecordQueryResult queryMore(RecordQueryResult queryResult) throws IOException;
+  RecordQueryResult queryMore(RecordQueryResult queryResult) throws DataApiException;
 
   /**
    * Returns the access token used by this API client. Can be used to initialize a third-party API

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApiException.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApiException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.sdk.data;
+
+/** Signals that a data API error occurred. */
+public final class DataApiException extends Exception {
+
+  /**
+   * Constructs a DataApiException with the specified detail message.
+   *
+   * @param message The detail message (which is saved for later retrieval by the {@link
+   *     Throwable#getMessage()} method)
+   */
+  @SuppressWarnings("unused")
+  public DataApiException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a DataApiException with the specified detail message and cause.
+   *
+   * @param message The detail message (which is saved for later retrieval by the {@link
+   *     Throwable#getMessage()} method)
+   * @param cause The cause (which is saved for later retrieval by the {@link Throwable#getCause()}
+   *     method). (A null value is permitted, and indicates that the cause is nonexistent or
+   *     unknown.)
+   */
+  @SuppressWarnings("unused")
+  public DataApiException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/ReferenceId.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/ReferenceId.java
@@ -6,10 +6,9 @@
  */
 package com.salesforce.functions.jvm.sdk.data;
 
-import javax.annotation.Nonnull;
-
-public interface ReferenceId {
-  @Nonnull
-  @SuppressWarnings("unused")
-  String toApiString();
-}
+/**
+ * References a record that will be created or modified in the future. It can be used to insert
+ * records that reference other records that will be created in the same {@link UnitOfWork}
+ * transaction.
+ */
+public interface ReferenceId {}


### PR DESCRIPTION
Various API changes in one PR. Concrete implementation will follow shortly in the runtime repository:

1. Allow `SalesforceFunction#apply` to throw `Exception`
References: [W-9041809](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008sXlYAI/view)
2. Replace `IOException` with  new `DataApiException` for better error handling in `DataApi`
References: [W-9041808](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008sXgYAI/view)
3. Remove `toApiString` from `ReferenceId` as it leaks implementation details.