### PR TITLE
Add DataApiError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.salesforce.functions</groupId>
     <artifactId>sf-fx-sdk-java</artifactId>
-    <version>0.2.1-ea-SNAPSHOT</version>
+    <version>0.3.0-ea-SNAPSHOT</version>
 
     <name>sf-fx-sdk-java</name>
     <description>Salesforce Function SDK for Java</description>

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApiError.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApiError.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.sdk.data;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * Represents an error from the Data API. Contains detailed information about the underlying error.
+ *
+ * @see <a
+ *     href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/errorcodes.htm">REST
+ *     API Developer Guide - Status Codes and Error Responses</a>
+ */
+public interface DataApiError {
+  /**
+   * Returns the message of this error.
+   *
+   * @return The message of this error.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getMessage();
+
+  /**
+   * Returns the error code for this error.
+   *
+   * @return The error code for this error.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  String getErrorCode();
+
+  /**
+   * Returns the field names where the error occurred. Might be empty for errors that are not
+   * related to a specific field.
+   *
+   * @return The field names where the error occurred.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  List<String> getFields();
+}

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApiException.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/DataApiException.java
@@ -6,8 +6,14 @@
  */
 package com.salesforce.functions.jvm.sdk.data;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+
 /** Signals that a data API error occurred. */
 public final class DataApiException extends Exception {
+  private final List<DataApiError> errors;
 
   /**
    * Constructs a DataApiException with the specified detail message.
@@ -18,6 +24,7 @@ public final class DataApiException extends Exception {
   @SuppressWarnings("unused")
   public DataApiException(String message) {
     super(message);
+    errors = Collections.unmodifiableList(new ArrayList<>());
   }
 
   /**
@@ -32,5 +39,32 @@ public final class DataApiException extends Exception {
   @SuppressWarnings("unused")
   public DataApiException(String message, Throwable cause) {
     super(message, cause);
+    errors = Collections.unmodifiableList(new ArrayList<>());
+  }
+
+  /**
+   * Constructs a DataApiException with the specified detail message and list of API errors.
+   *
+   * @param message The detail message (which is saved for later retrieval by the {@link
+   *     Throwable#getMessage()} method)
+   * @param errors The list API errors (which is saved for later retrieval by the {@link
+   *     #getDataApiErrors()} method)
+   */
+  @SuppressWarnings("unused")
+  public DataApiException(String message, List<DataApiError> errors) {
+    super(message);
+    this.errors = Collections.unmodifiableList(new ArrayList<>(errors));
+  }
+
+  /**
+   * Returns the list of {@link DataApiError}s that occurred. This list might be empty if the
+   * exception wasn't caused by an API error.
+   *
+   * @return The list of {@link DataApiError}s that occurred.
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  public List<DataApiError> getDataApiErrors() {
+    return errors;
   }
 }


### PR DESCRIPTION
Add `DataApiError` to transport errors from the underlying API to the user. Those contain detailed information about the error, for example unexpected tokens in SOQL query strings.

Since this change is incompatible with `0.2.x-ea` this PR also updates the version to `0.3.0-ea`.

References [W-9041808](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008sXgYAI/view)