### PR TITLE
Update Record interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.salesforce.functions</groupId>
     <artifactId>sf-fx-sdk-java</artifactId>
-    <version>0.3.1-ea-SNAPSHOT</version>
+    <version>0.4.0-ea-SNAPSHOT</version>
 
     <name>sf-fx-sdk-java</name>
     <description>Salesforce Function SDK for Java</description>

--- a/src/main/java/com/salesforce/functions/jvm/sdk/data/Record.java
+++ b/src/main/java/com/salesforce/functions/jvm/sdk/data/Record.java
@@ -11,7 +11,7 @@ import java.math.BigInteger;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
-/** Represents a read-only record in a Salesforce org. */
+/** Represents record in a Salesforce org. Implementations must be immutable. */
 public interface Record {
   /**
    * Returns the type of the record.
@@ -23,8 +23,8 @@ public interface Record {
   String getType();
 
   /**
-   * Returns the value of key as a {@link String}. Values that are not {@link String}s will be
-   * automatically converted to Strings. For example, if the record contains the number 42 at the
+   * Returns the value of {@code key} as a {@link String}. Values that are not {@link String}s will
+   * be automatically converted to Strings. For example, if the record contains the number 42 at the
    * given key, this method will return an {@link Optional} containing the String "42".
    *
    * @param key The key to obtain the value from.
@@ -36,7 +36,7 @@ public interface Record {
   Optional<String> getStringValue(String key);
 
   /**
-   * Returns the value of key as a {@link Character}. Works exactly the same way as {@link
+   * Returns the value of {@code key} as a {@link Character}. Works exactly the same way as {@link
    * #getStringValue(String)}, but only returns the first character.
    *
    * @param key The key to obtain the value from.
@@ -50,7 +50,7 @@ public interface Record {
   Optional<Character> getCharacterValue(String key);
 
   /**
-   * Returns the value of key as a {@link Boolean}.
+   * Returns the value of {@code key} as a {@link Boolean}.
    *
    * <p>If the value at the given key is not a boolean, it is converted to a {@link String} first,
    * and then parsed with {@link Boolean#parseBoolean(String)}. Effectively, this means that any
@@ -66,138 +66,223 @@ public interface Record {
   Optional<Boolean> getBooleanValue(String key);
 
   /**
-   * Returns the value of key as a {@link Number}.
+   * Returns the value of {@code key} as a {@link Byte}, which may involve rounding or truncation.
    *
    * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails a {@link NumberFormatException} is thrown.
+   * as one. This allows {@link String}s that represent numbers to be interpreted as numbers. If the
+   * value cannot be parsed as a number, a {@link NumberFormatException} is thrown.
    *
-   * @param key The key to obtain the value from.
-   * @throws NumberFormatException If the value at key could not be parsed as a {@link Number}
-   *     value.
-   * @return The value of the key as a {@link Number} or empty {@link Optional} if the value is not
-   *     present or null.
-   */
-  @Nonnull
-  @SuppressWarnings("unused")
-  Optional<Number> getNumberValue(String key);
-
-  /**
-   * Returns the value of key as a {@link Short}.
+   * <p>If the (if necessary, parsed) value cannot be directly represented as a {@link Byte} (i.e.
+   * the value is too large or contains decimals), it will be converted to a {@link Byte} which may
+   * involve rounding or truncation of the value.
    *
-   * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails, or the number cannot be represented as a {@link Short}, a {@link
-   * NumberFormatException} is thrown.
+   * <p>The conversion is analogous to a narrowing primitive conversion or a widening primitive
+   * conversion as defining in The Java® Language Specification for converting between primitive
+   * types. Therefore, conversions may lose information about the overall magnitude of a numeric
+   * value, may lose precision, and may even return a result of a different sign.
    *
-   * @param key The key to obtain the value from.
-   * @throws NumberFormatException If the value at key could not be parsed as a {@link Short} value.
-   * @return The value of the key as a {@link Short} or empty {@link Optional} if the value is not
-   *     present or null.
-   */
-  @Nonnull
-  @SuppressWarnings("unused")
-  Optional<Short> getShortValue(String key);
-
-  /**
-   * Returns the value of key as a {@link Long}.
-   *
-   * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails, or the number cannot be represented as a {@link Long}, a {@link
-   * NumberFormatException} is thrown.
-   *
-   * @param key The key to obtain the value from.
-   * @throws NumberFormatException If the value at key could not be parsed as a {@link Long} value.
-   * @return The value of the key as a {@link Long} or empty {@link Optional} if the value is not
-   *     present or null.
-   */
-  @Nonnull
-  @SuppressWarnings("unused")
-  Optional<Long> getLongValue(String key);
-
-  /**
-   * Returns the value of key as an {@link Integer}.
-   *
-   * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails, or the number cannot be represented as a {@link Integer}, a
-   * {@link NumberFormatException} is thrown.
-   *
-   * @param key The key to obtain the value from.
-   * @throws NumberFormatException If the value at key could not be parsed as an {@link Integer}
-   *     value.
-   * @return The value of the key as an {@link Integer} or empty {@link Optional} if the value is
-   *     not present or null.
-   */
-  @Nonnull
-  @SuppressWarnings("unused")
-  Optional<Integer> getIntValue(String key);
-
-  /**
-   * Returns the value of key as a {@link Float}.
-   *
-   * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails, or the number cannot be represented as a {@link Float}, a {@link
-   * NumberFormatException} is thrown.
-   *
-   * @param key The key to obtain the value from.
-   * @throws NumberFormatException If the value at key could not be parsed as a {@link Float} value.
-   * @return The value of the key as an {@link Float} or empty {@link Optional} if the value is not
-   *     present or null.
-   */
-  @Nonnull
-  @SuppressWarnings("unused")
-  Optional<Float> getFloatValue(String key);
-
-  /**
-   * Returns the value of key as a {@link Double}.
-   *
-   * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails, or the number cannot be represented as a {@link Double}, a
-   * {@link NumberFormatException} is thrown.
-   *
-   * @param key The key to obtain the value from.
-   * @throws NumberFormatException If the value at key could not be parsed as a {@link Double}
-   *     value.
-   * @return The value of the key as an {@link Double} or empty {@link Optional} if the value is not
-   *     present or null.
-   */
-  @Nonnull
-  @SuppressWarnings("unused")
-  Optional<Double> getDoubleValue(String key);
-
-  /**
-   * Returns the value of key as a {@link Byte}.
-   *
-   * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails, or the number cannot be represented as a {@link Byte}, a {@link
-   * NumberFormatException} is thrown.
+   * <p>If full control over the conversion is required, {@link #getBigDecimalValue(String)} can be
+   * used. {@link BigDecimal} offers an extensive suite of methods to convert from a {@link
+   * BigDecimal} to primitive number types.
    *
    * @param key The key to obtain the value from.
    * @throws NumberFormatException If the value at key could not be parsed as a {@link Byte} value.
    * @return The value of the key as an {@link Byte} or empty {@link Optional} if the value is not
    *     present or null.
+   * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html">The Java® Language
+   *     Specification - Chapter 5. Conversions and Contexts</a>
+   * @see #getBigDecimalValue(String)
    */
   @Nonnull
   @SuppressWarnings("unused")
   Optional<Byte> getByteValue(String key);
 
   /**
-   * Returns the value of key as an {@link BigInteger}.
+   * Returns the value of {@code key} as a {@link Short}, which may involve rounding or truncation.
    *
    * <p>If the type of the value at the given key is not a number, this method will try to parse it
-   * as one. If that process fails, or the number cannot be represented as a {@link BigInteger}, a
-   * {@link NumberFormatException} is thrown.
+   * as one. This allows {@link String}s that represent numbers to be interpreted as numbers. If the
+   * value cannot be parsed as a number, a {@link NumberFormatException} is thrown.
+   *
+   * <p>If the (if necessary, parsed) value cannot be directly represented as a {@link Short} (i.e.
+   * the value is too large or contains decimals), it will be converted to a {@link Short} which may
+   * involve rounding or truncation of the value.
+   *
+   * <p>The conversion is analogous to a narrowing primitive conversion or a widening primitive
+   * conversion as defining in The Java® Language Specification for converting between primitive
+   * types. Therefore, conversions may lose information about the overall magnitude of a numeric
+   * value, may lose precision, and may even return a result of a different sign.
+   *
+   * <p>If full control over the conversion is required, {@link #getBigDecimalValue(String)} can be
+   * used. {@link BigDecimal} offers an extensive suite of methods to convert from a {@link
+   * BigDecimal} to primitive number types.
+   *
+   * @param key The key to obtain the value from.
+   * @throws NumberFormatException If the value at key could not be parsed as a {@link Short} value.
+   * @return The value of the key as an {@link Short} or empty {@link Optional} if the value is not
+   *     present or null.
+   * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html">The Java® Language
+   *     Specification - Chapter 5. Conversions and Contexts</a>
+   * @see #getBigDecimalValue(String)
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Short> getShortValue(String key);
+
+  /**
+   * Returns the value of {@code key} as a {@link Integer}, which may involve rounding or
+   * truncation.
+   *
+   * <p>If the type of the value at the given key is not a number, this method will try to parse it
+   * as one. This allows {@link String}s that represent numbers to be interpreted as numbers. If the
+   * value cannot be parsed as a number, a {@link NumberFormatException} is thrown.
+   *
+   * <p>If the (if necessary, parsed) value cannot be directly represented as a {@link Integer}
+   * (i.e. the value is too large or contains decimals), it will be converted to a {@link Integer}
+   * which may involve rounding or truncation of the value.
+   *
+   * <p>The conversion is analogous to a narrowing primitive conversion or a widening primitive
+   * conversion as defining in The Java® Language Specification for converting between primitive
+   * types. Therefore, conversions may lose information about the overall magnitude of a numeric
+   * value, may lose precision, and may even return a result of a different sign.
+   *
+   * <p>If full control over the conversion is required, {@link #getBigDecimalValue(String)} can be
+   * used. {@link BigDecimal} offers an extensive suite of methods to convert from a {@link
+   * BigDecimal} to primitive number types.
+   *
+   * @param key The key to obtain the value from.
+   * @throws NumberFormatException If the value at key could not be parsed as a {@link Integer}
+   *     value.
+   * @return The value of the key as an {@link Integer} or empty {@link Optional} if the value is
+   *     not present or null.
+   * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html">The Java® Language
+   *     Specification - Chapter 5. Conversions and Contexts</a>
+   * @see #getBigDecimalValue(String)
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Integer> getIntValue(String key);
+
+  /**
+   * Returns the value of {@code key} as a {@link Long}, which may involve rounding or truncation.
+   *
+   * <p>If the type of the value at the given key is not a number, this method will try to parse it
+   * as one. This allows {@link String}s that represent numbers to be interpreted as numbers. If the
+   * value cannot be parsed as a number, a {@link NumberFormatException} is thrown.
+   *
+   * <p>If the (if necessary, parsed) value cannot be directly represented as a {@link Long} (i.e.
+   * the value is too large or contains decimals), it will be converted to a {@link Long} which may
+   * involve rounding or truncation of the value.
+   *
+   * <p>The conversion is analogous to a narrowing primitive conversion or a widening primitive
+   * conversion as defining in The Java® Language Specification for converting between primitive
+   * types. Therefore, conversions may lose information about the overall magnitude of a numeric
+   * value, may lose precision, and may even return a result of a different sign.
+   *
+   * <p>If full control over the conversion is required, {@link #getBigDecimalValue(String)} can be
+   * used. {@link BigDecimal} offers an extensive suite of methods to convert from a {@link
+   * BigDecimal} to primitive number types.
+   *
+   * @param key The key to obtain the value from.
+   * @throws NumberFormatException If the value at key could not be parsed as a {@link Long} value.
+   * @return The value of the key as an {@link Long} or empty {@link Optional} if the value is not
+   *     present or null.
+   * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html">The Java® Language
+   *     Specification - Chapter 5. Conversions and Contexts</a>
+   * @see #getBigDecimalValue(String)
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Long> getLongValue(String key);
+
+  /**
+   * Returns the value of {@code key} as a {@link Float}, which may involve rounding or truncation.
+   *
+   * <p>If the type of the value at the given key is not a number, this method will try to parse it
+   * as one. This allows {@link String}s that represent numbers to be interpreted as numbers. If the
+   * value cannot be parsed as a number, a {@link NumberFormatException} is thrown.
+   *
+   * <p>If the (if necessary, parsed) value cannot be directly represented as a {@link Float} (i.e.
+   * the value is too large), it will be converted to a {@link Float} which may involve rounding or
+   * truncation of the value.
+   *
+   * <p>The conversion is analogous to a narrowing primitive conversion or a widening primitive
+   * conversion as defining in The Java® Language Specification for converting between primitive
+   * types. Therefore, conversions may lose information about the overall magnitude of a numeric
+   * value, may lose precision, and may even return a result of a different sign.
+   *
+   * <p>If full control over the conversion is required, {@link #getBigDecimalValue(String)} can be
+   * used. {@link BigDecimal} offers an extensive suite of methods to convert from a {@link
+   * BigDecimal} to primitive number types.
+   *
+   * @param key The key to obtain the value from.
+   * @throws NumberFormatException If the value at key could not be parsed as a {@link Float} value.
+   * @return The value of the key as an {@link Float} or empty {@link Optional} if the value is not
+   *     present or null.
+   * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html">The Java® Language
+   *     Specification - Chapter 5. Conversions and Contexts</a>
+   * @see #getBigDecimalValue(String)
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Float> getFloatValue(String key);
+
+  /**
+   * Returns the value of {@code key} as a {@link Double}, which may involve rounding or truncation.
+   *
+   * <p>If the type of the value at the given key is not a number, this method will try to parse it
+   * as one. This allows {@link String}s that represent numbers to be interpreted as numbers. If the
+   * value cannot be parsed as a number, a {@link NumberFormatException} is thrown.
+   *
+   * <p>If the (if necessary, parsed) value cannot be directly represented as a {@link Double} (i.e.
+   * the value is too large), it will be converted to a {@link Double} which may involve rounding or
+   * truncation of the value.
+   *
+   * <p>The conversion is analogous to a narrowing primitive conversion or a widening primitive
+   * conversion as defining in The Java® Language Specification for converting between primitive
+   * types. Therefore, conversions may lose information about the overall magnitude of a numeric
+   * value, may lose precision, and may even return a result of a different sign.
+   *
+   * <p>If full control over the conversion is required, {@link #getBigDecimalValue(String)} can be
+   * used. {@link BigDecimal} offers an extensive suite of methods to convert from a {@link
+   * BigDecimal} to primitive number types.
+   *
+   * @param key The key to obtain the value from.
+   * @throws NumberFormatException If the value at key could not be parsed as a {@link Double}
+   *     value.
+   * @return The value of the key as an {@link Double} or empty {@link Optional} if the value is not
+   *     present or null.
+   * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html">The Java® Language
+   *     Specification - Chapter 5. Conversions and Contexts</a>
+   * @see #getBigDecimalValue(String)
+   */
+  @Nonnull
+  @SuppressWarnings("unused")
+  Optional<Double> getDoubleValue(String key);
+
+  /**
+   * Returns the value of {@code key} as an {@link BigInteger} which may involve rounding.
+   *
+   * <p>If the type of the value at the given key is not a number, this method will try to parse it
+   * as one. If that process fails, a {@link NumberFormatException} is thrown.
+   *
+   * <p>If the (if necessary, parsed) value cannot be directly represented as a {@link BigInteger}
+   * (i.e. the value contains decimals), it will be converted to a {@link BigInteger} which may
+   * involve rounding. Use {@link #getBigDecimalValue(String)} support for decimals is required.
    *
    * @param key The key to obtain the value from.
    * @throws NumberFormatException If the value at key could not be parsed as a {@link BigInteger}
    *     value.
    * @return The value of the key as an {@link BigInteger} or empty {@link Optional} if the value is
    *     not present or null.
+   * @see #getBigDecimalValue(String)
    */
   @Nonnull
   @SuppressWarnings("unused")
   Optional<BigInteger> getBigIntegerValue(String key);
 
   /**
-   * Returns the value of key as an {@link BigDecimal}.
+   * Returns the value of {@code key} as an {@link BigDecimal}.
    *
    * <p>If the type of the value at the given key is not a number, this method will try to parse it
    * as one. If that process fails, or the number cannot be represented as a {@link BigDecimal}, a


### PR DESCRIPTION
- Remove `getNumberValue` as it does not bring much value since `BigDecimal` already is a `Number`. It also complicated documentation and implementation.
- Bump version to `0.4.0-ea` due to breaking API
- Update documentation on number returning values to clarify conversion rules