### PR TITLE
Add GitHub actions release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,68 @@
+name: Prepare release
+
+on: workflow_dispatch
+
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too, rather
+    # than only error on exit. This is important for UX since this workflow uses pipes. See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+jobs:
+  prepare-release:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # We always want the version bump/changelog and resultant PR to target main, not the branch of the workflow_dispatch.
+          ref: main
+
+      - name: Record latest release version
+        id: old-version
+        run: echo "version=$(gh release view --json tagName | jq -j '.tagName | sub("v"; "")')" >> "${GITHUB_OUTPUT}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Drop -SNAPSHOT suffix from version
+        run: ./mvnw versions:set -DremoveSnapshot -DgenerateBackupPoms=false
+
+      - name: Record new version
+        id: new-version
+        run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -B -DforceStdout)" >> "${GITHUB_OUTPUT}"
+
+      - name: Update changelog
+        run: |
+          OLD_VERSION='${{ steps.old-version.outputs.version }}'
+          NEW_VERSION='${{ steps.new-version.outputs.version }}'
+          DATE_TODAY="$(date --utc --iso-8601)"
+          UNRELEASED_URL="https://github.com/${{ github.repository }}/compare/v${NEW_VERSION}...HEAD"
+          NEW_VERSION_URL="https://github.com/${{ github.repository }}/compare/v${OLD_VERSION}...v${NEW_VERSION}"
+
+          sed --in-place --regexp-extended \
+            --expression "s~(^## \[Unreleased\])$~\1\n\n\n## [${NEW_VERSION}] - ${DATE_TODAY}~" \
+            --expression "s~(^\[unreleased\]:) .*$~\1 ${UNRELEASED_URL}\n[${NEW_VERSION}]: ${NEW_VERSION_URL}~" \
+            CHANGELOG.md
+
+      - name: Create pull request
+        id: pr
+        uses: peter-evans/create-pull-request@v5.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Prepare release v${{ steps.new-version.outputs.version }}
+          body: |
+            Changes:
+            https://github.com/${{ github.repository }}/compare/v${{ steps.old-version.outputs.version }}...main
+          commit-message: Prepare release v${{ steps.new-version.outputs.version }}
+          branch: prepare-release
+          delete-branch: true
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+
+      - name: Configure pull request
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on: workflow_dispatch
+
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too, rather
+    # than only error on exit. This is important for UX since this workflow uses pipes. See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+jobs:
+  release:
+    name: Release
+    # Prevent accidentally performing a release from a branch other than `main`.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          server-id: ossrh
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Record new version
+        id: new-version
+        run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -B -DforceStdout)" >> "${GITHUB_OUTPUT}"
+
+      - name: Check GitHub release does not already exist
+        run: |
+          if gh release view 'v${{ steps.new-version.outputs.version }}' --json url --jq '.url'; then
+            echo "Aborting since a GitHub release already exists for ${{ steps.new-version.outputs.version }}!" >&2
+            echo "If you are sure you want to recreate the release, delete the existing one first." >&2
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract changelog entry
+        id: changelog-entry
+        # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        run: |
+          {
+            echo 'content<<CHANGELOG_END'
+            awk '/^## \[${{ steps.new-version.outputs.version }}\]/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md
+            echo CHANGELOG_END
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Deploy project
+        run: ./mvnw --batch-mode deploy
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: v${{ steps.new-version.outputs.version }}
+          body: ${{ steps.changelog-entry.outputs.content }}
+
+      - name: Record next version
+        id: next-version
+        run: echo "version=$(echo ${{ steps.new-version.outputs.version }} | awk -F. -v OFS=. '{ $NF=sprintf("%d-SNAPSHOT", ($NF+1)); printf $0 }')" >> "${GITHUB_OUTPUT}"
+
+      - name: Update version
+        run: ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion="${{ steps.next-version.outputs.version }}"
+
+      - name: Create pull request
+        id: pr
+        uses: peter-evans/create-pull-request@v5.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Prepare next development iteration ${{ steps.next-version.outputs.version }}
+          body: |
+            Prepare next development iteration `${{ steps.next-version.outputs.version }}`.
+          commit-message: Prepare next development iteration ${{ steps.next-version.outputs.version }}
+          branch: prepare-next
+          delete-branch: true
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          labels: |
+            skip changelog
+
+      - name: Configure pull request
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We're migrating off of `ossrh-releaser` and will release JVM artifacts via GitHub Actions. This is a modified release action copied from the new one we use for Heroku repositories. It's untested at this point. After this PR has been merged, I can test the action from a branch so there will be hopefully one follow-up PR at most. :)

