### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Dependency updates.
+
+## [1.1.1] - 2023-10-10
+
+### Added
+
+- Ability to read a field as a `Record` object from query result sets when a nested object is returned. ([#106](https://github.com/forcedotcom/sf-fx-sdk-java/pull/106))
+
+[unreleased]: https://github.com/forcedotcom/sf-fx-sdk-java/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/forcedotcom/sf-fx-sdk-java/compare/v1.1.0...v1.1.1


### PR DESCRIPTION
This project didn't have a CHANGELOG. The new release workflows added in #131 require one. Instead of removing CHANGELOG related code from the workflow, this PR adds one. 